### PR TITLE
修复iphone下面的safari会报错的bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs-scroll",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "Linder Wang",
     "email": "linder0209@126.com",

--- a/src/scripts/Scroll.js
+++ b/src/scripts/Scroll.js
@@ -61,7 +61,7 @@ class Scroll {
     this.y = 0;
     this.maxAmplitude = _options.maxAmplitude;
     const {wrapper} = _options;
-    const [scroller] = wrapper.children;
+    const scroller = wrapper.children[0];
     // 包裹区域元素
     this.wrapper = wrapper;
     // 内层元素
@@ -394,7 +394,7 @@ class Scroll {
   getTouch(e) {
     let touch = e;
     if (e.changedTouches && e.changedTouches.length > 0) {
-      [touch] = e.changedTouches;
+      touch = e.changedTouches[0];
     }
     return touch;
   }


### PR DESCRIPTION
解析赋值babel编译之后有一个逻辑判断为"Symbol.iterator in Object(options})",options为htmlCollection类型。ios下面的safari会返回为false，然后babel就报解析赋值错误。其他浏览器都会返回true